### PR TITLE
Pass threshold and trigger_level to engine

### DIFF
--- a/ovos_ww_plugin_precise_onnx/__init__.py
+++ b/ovos_ww_plugin_precise_onnx/__init__.py
@@ -39,7 +39,11 @@ class PreciseOnnxHotwordPlugin(HotWordEngine):
             raise ValueError(f"Model not found: {model}")
 
         self.precise_model = expanduser(model)
-        self.engine = PreciseOnnxEngine(self.precise_model)
+        self.engine = PreciseOnnxEngine(
+            self.precise_model,
+            threshold=float(self.threshold),
+            trigger_level=int(self.trigger_level),
+        )
 
 
     @staticmethod


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hotword detection engine now supports configurable threshold and trigger level parameters, enabling fine-tuning of wake word detection sensitivity through plugin configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->